### PR TITLE
25.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "fromYaml": "fromYaml"
       },
       "locked": {
-        "lastModified": 1745523430,
-        "narHash": "sha256-EAYWV+kXbwsH+8G/8UtmcunDeKwLwSOyfcmzZUkWE/c=",
+        "lastModified": 1746562888,
+        "narHash": "sha256-YgNJQyB5dQiwavdDFBMNKk1wyS77AtdgDk/VtU6wEaI=",
         "owner": "SenchoPens",
         "repo": "base16.nix",
-        "rev": "58bfe2553d937d8af0564f79d5b950afbef69717",
+        "rev": "806a1777a5db2a1ef9d5d6f493ef2381047f2b89",
         "type": "github"
       },
       "original": {
@@ -70,11 +70,11 @@
     "firefox-gnome-theme": {
       "flake": false,
       "locked": {
-        "lastModified": 1743774811,
-        "narHash": "sha256-oiHLDHXq7ymsMVYSg92dD1OLnKLQoU/Gf2F1GoONLCE=",
+        "lastModified": 1744642301,
+        "narHash": "sha256-5A6LL7T0lttn1vrKsNOKUk9V0ittdW0VEqh6AtefxJ4=",
         "owner": "rafaelmardojai",
         "repo": "firefox-gnome-theme",
-        "rev": "df53a7a31872faf5ca53dd0730038a62ec63ca9e",
+        "rev": "59e3de00f01e5adb851d824cf7911bd90c31083a",
         "type": "github"
       },
       "original": {
@@ -84,7 +84,6 @@
       }
     },
     "flake-compat": {
-      "flake": false,
       "locked": {
         "lastModified": 1733328505,
         "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
@@ -120,6 +119,27 @@
         "type": "github"
       }
     },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "stylix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -130,27 +150,6 @@
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": [
-          "stylix",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -226,16 +225,16 @@
     "gnome-shell": {
       "flake": false,
       "locked": {
-        "lastModified": 1732369855,
-        "narHash": "sha256-JhUWbcYPjHO3Xs3x9/Z9RuqXbcp5yhPluGjwsdE2GMg=",
+        "lastModified": 1744584021,
+        "narHash": "sha256-0RJ4mJzf+klKF4Fuoc8VN8dpQQtZnKksFmR2jhWE1Ew=",
         "owner": "GNOME",
         "repo": "gnome-shell",
-        "rev": "dadd58f630eeea41d645ee225a63f719390829dc",
+        "rev": "52c517c8f6c199a1d6f5118fae500ef69ea845ae",
         "type": "github"
       },
       "original": {
         "owner": "GNOME",
-        "ref": "47.2",
+        "ref": "48.1",
         "repo": "gnome-shell",
         "type": "github"
       }
@@ -247,16 +246,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1747688870,
-        "narHash": "sha256-ypL9WAZfmJr5V70jEVzqGjjQzF0uCkz+AFQF7n9NmNc=",
+        "lastModified": 1749154018,
+        "narHash": "sha256-gjN3j7joRvT3a8Zgcylnd4NFsnXeDBumqiu4HmY1RIg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d5f1f641b289553927b3801580598d200a501863",
+        "rev": "7aae0ee71a17b19708b93b3ed448a1a0952bf111",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-24.11",
+        "ref": "release-25.05",
         "repo": "home-manager",
         "type": "github"
       }
@@ -269,16 +268,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1743808813,
-        "narHash": "sha256-2lDQBOmlz9ggPxcS7/GvcVdzXMIiT+PpMao6FbLJSr0=",
+        "lastModified": 1747556831,
+        "narHash": "sha256-Qb84nbYFFk0DzFeqVoHltS2RodAYY5/HZQKE8WnBDsc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a9f8b3db211b4609ddd83683f9db89796c7f6ac6",
+        "rev": "d0bbd221482c2713cccb80220f3c9d16a6e20a33",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-24.11",
+        "ref": "release-25.05",
         "repo": "home-manager",
         "type": "github"
       }
@@ -305,11 +304,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747540584,
-        "narHash": "sha256-cxCQ413JTUuRv9Ygd8DABJ1D6kuB/nTfQqC0Lu9C0ls=",
+        "lastModified": 1749355504,
+        "narHash": "sha256-L17CdJMD+/FCBOHjREQLXbe2VUnc3rjffenBbu2Kwpc=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "ec179dd13fb7b4c6844f55be91436f7857226dce",
+        "rev": "40a6e15e44b11fbf8f2b1df9d64dbfc117625e94",
         "type": "github"
       },
       "original": {
@@ -320,11 +319,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1747900541,
-        "narHash": "sha256-dn64Pg9xLETjblwZs9Euu/SsjW80pd6lr5qSiyLY1pg=",
+        "lastModified": 1749195551,
+        "narHash": "sha256-W5GKQHgunda/OP9sbKENBZhMBDNu2QahoIPwnsF6CeM=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "11f2d9ea49c3e964315215d6baa73a8d42672f06",
+        "rev": "4602f7e1d3f197b3cb540d5accf5669121629628",
         "type": "github"
       },
       "original": {
@@ -336,11 +335,11 @@
     },
     "nixos-unstable": {
       "locked": {
-        "lastModified": 1747744144,
-        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
+        "lastModified": 1749285348,
+        "narHash": "sha256-frdhQvPbmDYaScPFiCnfdh3B/Vh81Uuoo0w5TkWmmjU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
+        "rev": "3e3afe5174c561dee0df6f2c2b2236990146329f",
         "type": "github"
       },
       "original": {
@@ -352,27 +351,27 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747676747,
-        "narHash": "sha256-LXkWBVqilgx7Pohwqu/ABxDVw+Cmi5/Mj2S2mpUH0Fw=",
+        "lastModified": 1749494155,
+        "narHash": "sha256-FG4DEYBpROupu758beabUk9lhrblSf5hnv84v1TLqMc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "72841a4a8761d1aed92ef6169a636872c986c76d",
+        "rev": "88331c17ba434359491e8d5889cce872464052c2",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1747744144,
-        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
+        "lastModified": 1749285348,
+        "narHash": "sha256-frdhQvPbmDYaScPFiCnfdh3B/Vh81Uuoo0w5TkWmmjU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
+        "rev": "3e3afe5174c561dee0df6f2c2b2236990146329f",
         "type": "github"
       },
       "original": {
@@ -400,16 +399,16 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1743703532,
-        "narHash": "sha256-s1KLDALEeqy+ttrvqV3jx9mBZEvmthQErTVOAzbjHZs=",
+        "lastModified": 1747610100,
+        "narHash": "sha256-rpR5ZPMkWzcnCcYYo3lScqfuzEw5Uyfh+R0EKZfroAc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bdb91860de2f719b57eef819b5617762f7120c70",
+        "rev": "ca49c4304acf0973078db0a9d200fd2bae75676d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -421,16 +420,42 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1747932489,
-        "narHash": "sha256-ozBYu7pC8tIkO/bjN/1GUTsJPEQg/mZ4FQqshdQUl0c=",
+        "lastModified": 1749632218,
+        "narHash": "sha256-qq4rfaR0SnWgLGojMzp6bVmRXdlyk6VJKlBjkoFJtw4=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "79880960f03aa698c43dba062cac2329a3bedabc",
+        "rev": "f6a219551c6583b90534e38bdf8f3352151fa0da",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "repo": "nur",
+        "type": "github"
+      }
+    },
+    "nur_2": {
+      "inputs": {
+        "flake-parts": [
+          "stylix",
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "stylix",
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix_2"
+      },
+      "locked": {
+        "lastModified": 1746056780,
+        "narHash": "sha256-/emueQGaoT4vu0QjU9LDOG5roxRSfdY0K2KkxuzazcM=",
+        "owner": "nix-community",
+        "repo": "NUR",
+        "rev": "d476cd0972dd6242d76374fcc277e6735715c167",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "NUR",
         "type": "github"
       }
     },
@@ -486,27 +511,30 @@
         "base16-vim": "base16-vim",
         "firefox-gnome-theme": "firefox-gnome-theme",
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils_2",
+        "flake-parts": "flake-parts_2",
         "git-hooks": "git-hooks",
         "gnome-shell": "gnome-shell",
         "home-manager": "home-manager_2",
         "nixpkgs": "nixpkgs_4",
+        "nur": "nur_2",
         "systems": "systems_2",
         "tinted-foot": "tinted-foot",
         "tinted-kitty": "tinted-kitty",
-        "tinted-tmux": "tinted-tmux"
+        "tinted-schemes": "tinted-schemes",
+        "tinted-tmux": "tinted-tmux",
+        "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747771231,
-        "narHash": "sha256-DYdmj22ZvkN5x9/VtdV5Wnze+UaPuboYraCPnOWn6u4=",
+        "lastModified": 1749579811,
+        "narHash": "sha256-sdyK8oWWDwxGXLvHTzcSfcb3sAdIb9UJYPVWlgb3eUM=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "66f554e4e32d804bcf2c007a7b7efef04a3773b0",
+        "rev": "51fb6796fd61c6b9e02b950ccb8baccd8602de2e",
         "type": "github"
       },
       "original": {
         "owner": "danth",
-        "ref": "release-24.11",
+        "ref": "release-25.05",
         "repo": "stylix",
         "type": "github"
       }
@@ -561,28 +589,43 @@
     "tinted-kitty": {
       "flake": false,
       "locked": {
-        "lastModified": 1716423189,
-        "narHash": "sha256-2xF3sH7UIwegn+2gKzMpFi3pk5DlIlM18+vj17Uf82U=",
+        "lastModified": 1735730497,
+        "narHash": "sha256-4KtB+FiUzIeK/4aHCKce3V9HwRvYaxX+F1edUrfgzb8=",
         "owner": "tinted-theming",
         "repo": "tinted-kitty",
-        "rev": "eb39e141db14baef052893285df9f266df041ff8",
+        "rev": "de6f888497f2c6b2279361bfc790f164bfd0f3fa",
         "type": "github"
       },
       "original": {
         "owner": "tinted-theming",
         "repo": "tinted-kitty",
-        "rev": "eb39e141db14baef052893285df9f266df041ff8",
+        "type": "github"
+      }
+    },
+    "tinted-schemes": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1744974599,
+        "narHash": "sha256-Fg+rdGs5FAgfkYNCs74lnl8vkQmiZVdBsziyPhVqrlY=",
+        "owner": "tinted-theming",
+        "repo": "schemes",
+        "rev": "28c26a621123ad4ebd5bbfb34ab39421c0144bdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "schemes",
         "type": "github"
       }
     },
     "tinted-tmux": {
       "flake": false,
       "locked": {
-        "lastModified": 1743296873,
-        "narHash": "sha256-8IQulrb1OBSxMwdKijO9fB70ON//V32dpK9Uioy7FzY=",
+        "lastModified": 1745111349,
+        "narHash": "sha256-udV+nHdpqgkJI9D0mtvvAzbqubt9jdifS/KhTTbJ45w=",
         "owner": "tinted-theming",
         "repo": "tinted-tmux",
-        "rev": "af5152c8d7546dfb4ff6df94080bf5ff54f64e3a",
+        "rev": "e009f18a01182b63559fb28f1c786eb027c3dee9",
         "type": "github"
       },
       "original": {
@@ -591,9 +634,47 @@
         "type": "github"
       }
     },
+    "tinted-zed": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1725758778,
+        "narHash": "sha256-8P1b6mJWyYcu36WRlSVbuj575QWIFZALZMTg5ID/sM4=",
+        "owner": "tinted-theming",
+        "repo": "base16-zed",
+        "rev": "122c9e5c0e6f27211361a04fae92df97940eccf9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "base16-zed",
+        "type": "github"
+      }
+    },
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
+          "nur",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733222881,
+        "narHash": "sha256-JIPcz1PrpXUCbaccEnrcUS8jjEb/1vJbZz5KkobyFdM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "49717b5af6f80172275d47a418c9719a31a78b53",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "stylix",
           "nur",
           "nixpkgs"
         ]

--- a/flake.lock
+++ b/flake.lock
@@ -493,8 +493,8 @@
     },
     "secrets": {
       "locked": {
-        "lastModified": 1749584829,
-        "narHash": "sha256-CKfus49TmTCLSXlc92vE3CYOyH/FuURdr+Th34CwSuM=",
+        "lastModified": 1749645067,
+        "narHash": "sha256-nKRa6pyvcYMZTgEFFvmNCpeQvNAfS5/BPvWuytln2F8=",
         "path": "/home/farlion/code/nixos-secrets",
         "type": "path"
       },

--- a/flake.lock
+++ b/flake.lock
@@ -493,8 +493,8 @@
     },
     "secrets": {
       "locked": {
-        "lastModified": 1749645067,
-        "narHash": "sha256-nKRa6pyvcYMZTgEFFvmNCpeQvNAfS5/BPvWuytln2F8=",
+        "lastModified": 1749668463,
+        "narHash": "sha256-T1mIkpR3UL6mFW2wQi1lIBai7pyiOm4ees4s+ucSxa0=",
         "path": "/home/farlion/code/nixos-secrets",
         "type": "path"
       },

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     home-manager = {
-      url = "github:nix-community/home-manager/release-24.11";
+      url = "github:nix-community/home-manager/release-25.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     impermanence.url = "github:nix-community/impermanence";
@@ -11,13 +11,13 @@
       url = "github:nix-community/nix-index-database";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
     nixos-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
     nixos-hardware.url = "github:nixos/nixos-hardware/master";
     nur.url = "github:nix-community/nur";
     rmob.url = "https://flakehub.com/f/workflow/rmob/*.tar.gz";
     secrets.url = "path:/home/farlion/code/nixos-secrets";
-    stylix.url = "github:danth/stylix/release-24.11";
+    stylix.url = "github:danth/stylix/release-25.05";
   };
 
   outputs = {

--- a/home/brave-browser/default.nix
+++ b/home/brave-browser/default.nix
@@ -22,19 +22,19 @@ in {
     BROWSER =
       if isFlexbox
       then "brave --enable-features='VaapiVideoDecoder,VaapiVideoEncoder' --enable-raw-draw --password-store=seahorse"
-      else "brave";
+      else "brave --password-store=seahorse";
     DEFAULT_BROWSER =
       if isFlexbox
       then "brave --enable-features='VaapiVideoDecoder,VaapiVideoEncoder' --enable-raw-draw --password-store=seahorse"
-      else "brave";
+      else "brave --password-store=seahorse";
   };
 
   xdg.desktopEntries = {
     brave-browser = {
       exec =
         if isFlexbox
-        then "${pkgs.brave}/bin/brave --enable-features=VaapiVideoDecoder,VaapiVideoEncoder --enable-raw-draw %U"
-        else "${pkgs.brave}/bin/brave";
+        then "${pkgs.brave}/bin/brave --enable-features=VaapiVideoDecoder,VaapiVideoEncoder --enable-raw-draw %U --password-store=seahorse"
+        else "${pkgs.brave}/bin/brave --password-store=seahorse";
       name = "Brave Browser";
       comment = "Access the Internet";
       genericName = "Web Browser";

--- a/home/cliphist/default.nix
+++ b/home/cliphist/default.nix
@@ -22,7 +22,7 @@ in {
 
   services.cliphist = {
     enable = true;
-    systemdTarget = "sway-session.target";
+    systemdTargets = ["sway-session.target"];
   };
 
   home.packages = [cliphist-fuzzel-img pkgs.xdg-utils]; # For image copy/pasting

--- a/home/ddc-backlight/scripts/ddc-backlight.sh
+++ b/home/ddc-backlight/scripts/ddc-backlight.sh
@@ -19,7 +19,7 @@ fi 9>"$LOCK_FILE"
 # Check if monitor is connected and turned on - with better error handling
 # 1. Attempt to read the power state of the monitor using VCP code 0xD6 (Power Mode)
 {
-	timeout 2 ddcutil getvcp D6 -b "$BUS" --noverify --sleep-multiplier 2.0 >/dev/null
+	timeout 2 ddcutil getvcp D6 -b "$BUS" >/dev/null
 	power_status=$?
 } || {
 	power_status=1
@@ -33,7 +33,7 @@ fi
 
 # Otherwise, we can safely get brightness value without overloading the kernel...
 {
-	output=$(timeout 2 ddcutil getvcp 10 -b "$BUS" --noverify --sleep-multiplier 2.0 2>&1)
+	output=$(timeout 2 ddcutil getvcp 10 -b "$BUS" 2>&1)
 	status=$?
 } || {
 	status=1

--- a/home/default.nix
+++ b/home/default.nix
@@ -165,7 +165,7 @@ in {
       gomatrix # The Matrix
       google-chrome
       gucharmap # Unicode Character Map
-      hardinfo # Hardware/System Info
+      hardinfo2 # Hardware/System Info
       httpie
       iftop # Net top tool, see also nethogs
       imagemagick
@@ -185,7 +185,7 @@ in {
       neo-cowsay
       nix-tree
       oculante # img viewer written in Rust
-      okular # KDE document viewer
+      kdePackages.okular # KDE document viewer
       openssl
       pdftk # PDF Manipulation Toolkit
       pstree # Show the set of running processes as a tree
@@ -207,7 +207,7 @@ in {
       wireguard-tools
       whois
       wl-clipboard
-      xournal # PFD Annotations, useful for saving Okular annotations as well
+      xournalpp # PDF Annotations, useful for saving Okular annotations as well
       yq # Command-line YAML/XML/TOML processor - jq wrapper for YAML, XML, TOML documents
       yt-dlp
       zip
@@ -225,10 +225,6 @@ in {
   };
 
   inherit imports;
-
-  nixpkgs.config = {
-    allowUnfree = true;
-  };
 
   programs = {
     bat = {

--- a/home/default.nix
+++ b/home/default.nix
@@ -95,7 +95,7 @@
       ./udiskie
       ./urxvt
       ./variety # Wallpaper Switcher/Randomizer with Quotes
-      ./virtual-cable
+      ./virtual-cable # Virtual inputs/outputs via Pipewire (for OBS and beyond)
       ./vlc
       ./wlsunset # Day/night gamma adjustments for Wayland
       ./xdg

--- a/home/firefox/default.nix
+++ b/home/firefox/default.nix
@@ -15,7 +15,7 @@
     enable = true;
     profiles = {
       main = {
-        extensions = with pkgs.nur.repos.rycee.firefox-addons; [
+        extensions.packages = with pkgs.nur.repos.rycee.firefox-addons; [
           bitwarden
         ];
         id = 0;

--- a/home/fish/default.nix
+++ b/home/fish/default.nix
@@ -106,48 +106,10 @@
   ];
 
   shellInit = ''
-    if test -e $HOME/.local-fishrc
-      source $HOME/.local-fishrc
-    end
-
     thefuck --alias | source
 
     ${variables}
-    ${theme}
   '';
-
-  theme =
-    /*
-    fish
-    */
-    ''
-      set -g fish_color_autosuggestion 586e75
-      set -g fish_color_cancel -r
-      set -g fish_color_command 93a1a1
-      set -g fish_color_comment 586e75
-      set -g fish_color_cwd green
-      set -g fish_color_cwd_root red
-      set -g fish_color_end 268bd2
-      set -g fish_color_error dc322f
-      set -g fish_color_escape 00a6b2
-      set -g fish_color_history_current --bold
-      set -g fish_color_host normal
-      set -g fish_color_match --background=blue
-      set -g fish_color_normal normal
-      set -g fish_color_operator 00a6b2
-      set -g fish_color_param 839496
-      set -g fish_color_quote 657b83
-      set -g fish_color_redirection 6c71c4
-      set -g fish_color_search_match bryellow --background=405555
-      set -g fish_color_selection white --bold --background=black
-      set -g fish_color_status red
-      set -g fish_color_user brgreen
-      set -g fish_color_valid_path --underline
-      set -g fish_pager_color_completion B3A06D
-      set -g fish_pager_color_description B3A06D
-      set -g fish_pager_color_prefix cyan --underline
-      set -g fish_pager_color_progress brwhite --background=cyan
-    '';
 
   variables =
     /*

--- a/home/fish/default.nix
+++ b/home/fish/default.nix
@@ -159,10 +159,8 @@
     '';
 in {
   home.persistence."/persist/home/farlion" = lib.mkIf isImpermanent {
-    files = [
-      ".config/fish/fish_variables"
-    ];
     directories = [
+      ".config/fish"
       ".local/share/fish" # contains some unecessary state, but https://github.com/fish-shell/fish-shell/issues/10730 prevents us from only syncing the history file (.local/share/fish/fish_history)
     ];
   };

--- a/home/fish/default.nix
+++ b/home/fish/default.nix
@@ -14,21 +14,25 @@
         fish_vi_key_bindings
 
         # VI mode updates
-        bind -s --preset -M default j backward-char
-        bind -s --preset -M default \; forward-char
+        bind -s --preset --mode default j backward-char
+        bind -s --preset --mode default \; forward-char
         bind -s --preset k down-or-search
         bind -s --preset l up-or-search
-        bind -s --preset -M visual j backward-char
-        bind -s --preset -M visual \; forward-char
-        bind -s --preset -M visual l up-line
-        bind -s --preset -M visual k down-line
+        bind -s --preset --mode visual j backward-char
+        bind -s --preset --mode visual \; forward-char
+        bind -s --preset --mode visual l up-line
+        bind -s --preset --mode visual k down-line
 
         # Completions
-        bind -s -M insert \cw forward-word
+        bind -s --mode insert \cw forward-word
         # Tab --> accept autosuggestions
-        bind -s -M insert \t accept-autosuggestion
+        bind -s --mode insert \t accept-autosuggestion
         # CTRL-S --> original TAB behaviour
-        bind -s -M insert \cs complete
+        bind -s --mode insert \cs complete
+
+        # Bang-Bang bindings, manually added so they have precedence:
+        bind --mode insert ! __history_previous_command
+        bind --mode insert '$' __history_previous_command_arguments
       '';
 
     ## Wrap LF to add ability to quit with Q in current directory
@@ -93,15 +97,10 @@
       '';
   };
 
-  plugins = [
+  plugins = with pkgs.fishPlugins; [
     {
       name = "bang-bang";
-      src = pkgs.fetchFromGitHub {
-        owner = "oh-my-fish";
-        repo = "plugin-bang-bang";
-        rev = "ec991b80ba7d4dda7a962167b036efc5c2d79419";
-        sha256 = "oPPCtFN2DPuM//c48SXb4TrFRjJtccg0YPXcAo0Lxq0=";
-      };
+      src = bang-bang.src;
     }
   ];
 

--- a/home/git/github-cli/gh.config.yml
+++ b/home/git/github-cli/gh.config.yml
@@ -8,4 +8,5 @@ prompt: enabled
 pager:
 # Aliases allow you to create nicknames for gh commands
 aliases:
-    co: pr checkout
+  co: pr checkout
+version: 1

--- a/home/i3status-rust/default.nix
+++ b/home/i3status-rust/default.nix
@@ -333,7 +333,7 @@ in {
           ++ lib.lists.optionals isNumenor [
             {
               block = "custom";
-              command = "ddc-backlight 6"; # For i2c-6
+              command = "ddc-backlight 7"; # For i2c-7
               format = "$icon$text";
               icons_overrides = {
                 "moon_empty" = "🌑";
@@ -347,14 +347,15 @@ in {
               click = [
                 {
                   button = "up";
-                  cmd = "flock /tmp/ddc_backlight.lock ddcutil setvcp 10 + 5 -b 6";
+                  cmd = "flock /tmp/ddc_backlight.lock ddcutil setvcp 10 + 5 -b 7";
                 }
                 {
                   button = "down";
-                  cmd = "flock /tmp/ddc_backlight.lock ddcutil setvcp 10 - 5 -b 6";
+                  cmd = "flock /tmp/ddc_backlight.lock ddcutil setvcp 10 - 5 -b 7";
                 }
               ];
               json = true;
+              merge_with_next = true;
             }
             {
               block = "custom";
@@ -384,7 +385,7 @@ in {
             }
             {
               block = "custom";
-              command = "ddc-backlight 7"; # For i2c-7
+              command = "ddc-backlight 6"; # For i2c-6
               format = "$icon$text";
               icons_overrides = {
                 "moon_empty" = "🌑";
@@ -398,11 +399,11 @@ in {
               click = [
                 {
                   button = "up";
-                  cmd = "flock /tmp/ddc_backlight.lock ddcutil setvcp 10 + 5 -b 7";
+                  cmd = "flock /tmp/ddc_backlight.lock ddcutil setvcp 10 + 5 -b 6";
                 }
                 {
                   button = "down";
-                  cmd = "flock /tmp/ddc_backlight.lock ddcutil setvcp 10 - 5 -b 7";
+                  cmd = "flock /tmp/ddc_backlight.lock ddcutil setvcp 10 - 5 -b 6";
                 }
               ];
               json = true;

--- a/home/neovim/default.nix
+++ b/home/neovim/default.nix
@@ -6,16 +6,6 @@
   ...
 }: let
   isLightTheme = osConfig.specialisation != {};
-
-  lf-nvim = pkgs.vimUtils.buildVimPlugin {
-    name = "lf-nvim";
-    src = pkgs.fetchFromGitHub {
-      owner = "lmburns";
-      repo = "lf.nvim";
-      rev = "69ab1efcffee6928bf68ac9bd0c016464d9b2c8b";
-      sha256 = "ys3kgXtgaE5OGyNYZ2PuqM9FDGjxfIjRgXBUDBVIjUM=";
-    };
-  };
 in {
   home.persistence."/persist/home/farlion" = lib.mkIf isImpermanent {
     directories = [
@@ -294,19 +284,6 @@ in {
           wk.add({
             { "[i", function() require("ibl").setup_buffer(0, {enabled = true}) end, desc = "Indentation Guides ON" },
             { "]i", function() require("ibl").setup_buffer(0, {enabled = false}) end, desc = "Indentation Guides OFF" },
-          })
-        '';
-        type = "lua";
-      }
-      {
-        plugin = lf-nvim;
-        config = ''
-          require("lf").setup({
-            border = "rounded",
-          })
-          local wk = require("which-key")
-          wk.add({
-            {"<leader>fl", "<cmd>Lf<cr>" , desc = "[L]f" },
           })
         '';
         type = "lua";

--- a/home/neovim/mason-lsp/default.nix
+++ b/home/neovim/mason-lsp/default.nix
@@ -1,15 +1,4 @@
-{pkgs, ...}: let
-  mason-nvim-dap = pkgs.vimUtils.buildVimPlugin {
-    name = "mason-nvim-dap";
-    src = pkgs.fetchFromGitHub {
-      owner = "jay-babu";
-      repo = "mason-nvim-dap.nvim";
-      rev = "67210c0e775adec55de9826b038e8b62de554afc";
-      sha256 = "KhTAomLm57MWWNvLaOeaMGGHJK7uLiNBY0XCyQ1TLSY=";
-    };
-  };
-in {
-  # home.packages = [pkgs.nodejs]; # Pyright and other LSPs need a global npm :(
+{pkgs, ...}: {
   programs.neovim.plugins = with pkgs.vimPlugins; [
     {
       plugin = mason-nvim; # Automatically install LSP servers
@@ -23,7 +12,7 @@ in {
       plugin = mason-lspconfig-nvim; # Automatically install LSP servers
     }
     {
-      plugin = mason-nvim-dap; # Automatically install LSP servers
+      plugin = mason-nvim-dap-nvim; # Automatically configure DAP adapters
     }
   ];
 }

--- a/home/neovim/neotest/default.nix
+++ b/home/neovim/neotest/default.nix
@@ -1,14 +1,4 @@
-{pkgs, ...}: let
-  neotest-vim-test = pkgs.vimUtils.buildVimPlugin {
-    name = "neotest-vim-test";
-    src = pkgs.fetchFromGitHub {
-      owner = "nvim-neotest";
-      repo = "neotest-vim-test";
-      rev = "75c4228882ae4883b11bfce9b8383e637eb44192";
-      sha256 = "fFm5Yt2Sus5jLSapHUtLlDkBWPLLKfWsj2NSXD8NPYo=";
-    };
-  };
-in {
+{pkgs, ...}: {
   programs.neovim.plugins = with pkgs.vimPlugins; [
     {
       plugin = FixCursorHold-nvim;
@@ -23,9 +13,6 @@ in {
     }
     {
       plugin = neotest-rust;
-    }
-    {
-      plugin = neotest-vim-test;
     }
     {
       plugin = nvim-nio;

--- a/home/neovim/neotest/neotest.lua
+++ b/home/neovim/neotest/neotest.lua
@@ -2,9 +2,6 @@ require("neotest").setup({
   adapters = {
     require("neotest-rust") {
     },
-    require("neotest-vim-test")({
-      -- ignore_file_types = { "java" },
-    }),
   },
   consumers = {
     overseer = require("neotest.consumers.overseer"),

--- a/home/neovim/none-ls/default.nix
+++ b/home/neovim/none-ls/default.nix
@@ -3,28 +3,20 @@
   pkgs,
   ...
 }: let
-  none-ls = pkgs.vimUtils.buildVimPlugin {
-    name = "none-ls";
-    src = pkgs.fetchFromGitHub {
-      owner = "nvimtools";
-      repo = "none-ls.nvim";
-      rev = "a117163db44c256d53c3be8717f3e1a2a28e6299";
-      sha256 = "KP/mS6HfVbPA5javQdj/x8qnYYk0G6oT0RZaPTAPseM=";
-    };
-  };
   none-ls-extras = pkgs.vimUtils.buildVimPlugin {
     name = "none-ls-extras";
+    doCheck = false;
     src = pkgs.fetchFromGitHub {
       owner = "nvimtools";
       repo = "none-ls-extras.nvim";
-      rev = "1214d729e3408470a7b7a428415a395e5389c13c";
-      sha256 = "5wQHdV2lmxMegN/BPg+qfGTNGv/T9u+hy4Yaj41PchI=";
+      rev = "924fe88a9983c7d90dbb31fc4e3129a583ea0a90";
+      sha256 = "sha256-OJHg2+h3zvlK7LJ8kY6f7et0w6emnxfcDbjD1YyWRTw=";
     };
   };
 in {
-  programs.neovim.plugins = [
+  programs.neovim.plugins = with pkgs.vimPlugins; [
     {
-      plugin = none-ls; # Automatically install LSP servers
+      plugin = none-ls-nvim; # Automatically install LSP servers
       config = builtins.readFile ./none-ls.lua;
       type = "lua";
     }

--- a/home/nh/default.nix
+++ b/home/nh/default.nix
@@ -2,6 +2,6 @@
   home.packages = [pkgs.nh];
 
   home.sessionVariables = {
-    FLAKE = "/home/farlion/code/nixos-config";
+    NH_FLAKE = "/home/farlion/code/nixos-config";
   };
 }

--- a/home/obs/default.nix
+++ b/home/obs/default.nix
@@ -20,16 +20,10 @@ in {
       obs-vintage-filter
     ];
   };
-  xdg.desktopEntries = {
+  xdg.desktopEntries = lib.mkIf isFlexbox {
     obs = {
-      name =
-        if isFlexbox
-        then "OBS Studio (NVIDIA GPU)"
-        else "OBS Studio";
-      exec =
-        if isFlexbox
-        then "nvidia-offload obs"
-        else "obs";
+      name = "OBS Studio (NVIDIA GPU)";
+      exec = "nvidia-offload obs";
       genericName = "Streaming/Recording Software";
       terminal = false;
       type = "Application";

--- a/home/sway/default.nix
+++ b/home/sway/default.nix
@@ -298,11 +298,11 @@ in {
         "${mod}+b" =
           if isFlexbox
           then "exec \"brave --profile-directory='Default' --enable-features='VaapiVideoDecoder,VaapiVideoEncoder' --enable-raw-draw --password-store=seahorse\""
-          else "exec \"brave --profile-directory='Default'\"";
+          else "exec \"brave --profile-directory='Default' --password-store=seahorse\"";
         "${mod}+h" =
           if isFlexbox
           then "exec \"brave --profile-directory='Profile 1' --enable-features='VaapiVideoDecoder,VaapiVideoEncoder' --enable-raw-draw --password-store=seahorse\""
-          else "exec \"brave --profile-directory='Profile 1'\"";
+          else "exec \"brave --profile-directory='Profile 1' --password-store=seahorse\"";
 
         # File Manager ("navigate")
         "${mod}+n" = "exec \"alacritty -e fish -ic lf\"";

--- a/home/sway/default.nix
+++ b/home/sway/default.nix
@@ -12,7 +12,7 @@
 
   networkManager = "${pkgs.networkmanager_dmenu}/bin/networkmanager_dmenu";
 
-  locker = "${pkgs.bash}/bin/bash -c 'pgrep -x swaylock || ${pkgs.swaylock}/bin/swaylock --daemonize'";
+  locker = "${pkgs.bash}/bin/bash -c '${pkgs.procps}/bin/pgrep -x swaylock || ${pkgs.swaylock}/bin/swaylock --daemonize'";
   suspender = "${pkgs.systemd}/bin/systemctl suspend-then-hibernate";
 
   mod = "Mod4";
@@ -61,7 +61,11 @@ in {
 
   programs.swaylock = {
     enable = true;
-    package = pkgs.swaylock;
+    settings = {
+      debug = true;
+      show-failed-attempts = true;
+      ignore-empty-password = true;
+    };
   };
 
   services.swayidle = {
@@ -80,8 +84,8 @@ in {
       }
       {
         timeout = 370;
-        command = "${pkgs.sway}/bin/swaymsg 'output * dpms off'";
-        resumeCommand = "${pkgs.sway}/bin/swaymsg 'output * dpms on'";
+        command = "/etc/profiles/per-user/farlion/bin/swaymsg 'output * dpms off'";
+        resumeCommand = "${pkgs.coreutils}/bin/sleep 1; /etc/profiles/per-user/farlion/bin/swaymsg 'output * power on'";
       }
       {
         timeout = 1800;

--- a/system/fonts/default.nix
+++ b/system/fonts/default.nix
@@ -35,7 +35,7 @@ in {
       pkgs.font-awesome_4
       pkgs.font-awesome_5
       pkgs.font-awesome_6
-      (pkgs.nerdfonts.override {fonts = ["FiraCode"];})
+      pkgs.nerd-fonts.fira-code
       pkgs.noto-fonts-color-emoji # emoji font
     ];
     fontconfig = {

--- a/system/kernel/default.nix
+++ b/system/kernel/default.nix
@@ -6,9 +6,9 @@
     "vm.swappiness" = 20; # balanced setting favoring RAM usage, Default=60
   };
 
-  # boot.kernelPackages = pkgs.linuxPackages_zen; # Optimized for desktop use
+  boot.kernelPackages = pkgs.linuxPackages_zen; # Optimized for desktop use
   # Temporary pin to work around NVidia driver issues, see https://github.com/NixOS/nixpkgs/issues/375730#issuecomment-2625234288
-  boot.kernelPackages = pkgs.linuxPackages_6_12; # Optimized for desktop use
+  # boot.kernelPackages = pkgs.linuxPackages_6_12;
   environment.systemPackages = with pkgs; [
     linuxKernel.packages.linux_zen.perf
     linuxKernel.packages.linux_zen.cpupower

--- a/system/video/default.nix
+++ b/system/video/default.nix
@@ -8,7 +8,20 @@
   boot.extraModprobeConfig = ''
     options v4l2loopback devices=1 video_nr=7 card_label="OBS Cam" exclusive_caps=1
   '';
-  boot.extraModulePackages = with config.boot.kernelPackages; [v4l2loopback];
+  # OBS virtual cam fix until OBS 31.1 is released
+  boot.extraModulePackages = [
+    (pkgs.linuxPackages_zen.v4l2loopback.overrideAttrs (_: {
+      version = "0.13.2-manual";
+      src = pkgs.fetchFromGitHub {
+        owner = "umlaeute";
+        repo = "v4l2loopback";
+        rev = "v0.13.2";
+        hash = "sha256-rcwgOXnhRPTmNKUppupfe/2qNUBDUqVb3TeDbrP5pnU=";
+      };
+    }))
+  ];
+  # TODO: Once fixed, consider using NixOS programs.obs-studio.enableVirtualCamera instead
+  # boot.extraModulePackages = with config.boot.kernelPackages; [v4l2loopback];
   boot.kernelModules = ["v4l2loopback"];
 
   environment.systemPackages = [


### PR DESCRIPTION
- **feat: Upgrade to 25.05 Warbler**
- **fix(nvim): remove broken neotest-vim-test**
- **fix(nh): update NH_FLAKE env var**
- **fix(fish/impermanence): store entire config dir**
- **feat(fish): clean up theming and other stuff**
- **fix(brave): force seahorse use**
- **fix(i3status-rust/numenor): ddc block ordering**
- **fix(flexbox/obs): make nvidia-offload desktop entry flexbox only**
- **docs(virtual-cable): add comment**
- **fix(swayidle): improve resilience and fix paths**
- **fix(obs): downgrade v4l2loopback until obs can handle the kernel changes**
- **feat(ddc-backlight): remove some tweaks that are hopefully no longer needed**
- **fix(fish/bang-bang): manually add keybindings as suggested in README**
- **fix(github-cli): migrate config file format**
